### PR TITLE
[2.x] Implements ArchitectureViolationException to display right collision editor on violation

### DIFF
--- a/src/Exception/ArchitectureViolationException.php
+++ b/src/Exception/ArchitectureViolationException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Arch\Exception;
+
+use Exception;
+use NunoMaduro\Collision\Contracts\RenderableOnCollisionEditor;
+use Pest\Arch\ValueObjects\ViolationReference;
+use Whoops\Exception\Frame;
+
+final class ArchitectureViolationException extends Exception implements RenderableOnCollisionEditor //@phpstan-ignore-line
+{
+    public function __construct(string $message, private readonly ViolationReference $reference)
+    {
+        parent::__construct($message);
+    }
+
+    public function toCollisionEditor(): Frame
+    {
+        return new Frame([
+            'file' => $this->reference->path,
+            'line' => $this->reference->start,
+        ]);
+    }
+}

--- a/src/ValueObjects/ViolationReference.php
+++ b/src/ValueObjects/ViolationReference.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Arch\ValueObjects;
+
+final class ViolationReference
+{
+    public function __construct(public readonly string $path, public readonly int $start, public readonly int $end)
+    {
+    }
+}

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -16,6 +16,8 @@ test('base')
         'Pest',
         'PHPUnit\Architecture',
         'Symfony\Component\Finder\Finder',
+        'PhpParser\Node',
+        'Whoops\Exception\Frame',
     ])->ignoring(['PHPUnit\Framework', 'Composer']);
 
 test('collections')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,7 +1,21 @@
 <?php
 
+use Pest\Arch\Exception\ArchitectureViolationException;
+
 uses()->beforeEach(function () {
     $this->arch()->ignore([
         'NunoMaduro\Collision',
     ]);
 })->in(__DIR__);
+
+expect()->extend('toThrowArchitectureViolation', function (string $message, string $file, int $line) {
+    return $this->toThrow(function (ArchitectureViolationException $exception) use ($line, $file, $message) {
+        $frame = $exception->toCollisionEditor();
+        $violationFile = str_replace(DIRECTORY_SEPARATOR, '/', $frame->getFile());
+        $violationLine = $frame->getLine();
+
+        expect($exception->getMessage())->toBe($message)
+            ->and($violationFile)->toEndWith($file)
+            ->and($violationLine)->toBe($line);
+    });
+});

--- a/tests/ToBeUsedInNothing.php
+++ b/tests/ToBeUsedInNothing.php
@@ -1,7 +1,6 @@
 <?php
 
 use Pest\Exceptions\InvalidExpectation;
-use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Fixtures\Contracts\Models\Fooable;
 use Tests\Fixtures\Support\Env;
 
@@ -16,18 +15,20 @@ it('passes as aliases', function () {
 });
 
 it('fails 1', function () {
-    expect(Fooable::class)->toBeUsedInNothing();
-})->throws(
-    ExpectationFailedException::class,
-    "Expecting 'Tests\Fixtures\Contracts\Models\Fooable' not to be used on 'Tests\Fixtures\Models\Product'."
-);
+    expect(fn () => expect(Fooable::class)->toBeUsedInNothing())->toThrowArchitectureViolation(
+        "Expecting 'Tests\Fixtures\Contracts\Models\Fooable' not to be used on 'Tests\Fixtures\Models\Product'.",
+        'tests/Fixtures/Models/Product.php',
+        8
+    );
+});
 
 it('fails 2', function () {
-    expect(Fooable::class)->not->toBeUsed();
-})->throws(
-    ExpectationFailedException::class,
-    "Expecting 'Tests\Fixtures\Contracts\Models\Fooable' not to be used on 'Tests\Fixtures\Models\Product'."
-);
+    expect(fn () => expect(Fooable::class)->not->toBeUsed())->toThrowArchitectureViolation(
+        "Expecting 'Tests\Fixtures\Contracts\Models\Fooable' not to be used on 'Tests\Fixtures\Models\Product'.",
+        'tests/Fixtures/Models/Product.php',
+        8
+    );
+});
 
 test('ignoring', function () {
     expect(Fooable::class)->toBeUsedInNothing()->ignoring('Tests\Fixtures\Models');

--- a/tests/ToOnlyBeUsedIn.php
+++ b/tests/ToOnlyBeUsedIn.php
@@ -26,7 +26,9 @@ it('fail 1', function () {
 })->throws(ExpectationFailedException::class, "Expecting 'Tests\Fixtures\Models\User' to use 'Tests\Fixtures\Contracts\Models\Storable'.");
 
 it('fail 2', function () {
-    expect(Barable::class)->toOnlyBeUsedIn([
-        User::class,
-    ]);
-})->throws(ExpectationFailedException::class, "Tests\Fixtures\Contracts\Models\Barable' not to be used on 'Tests\Fixtures\Models\Product'.");
+    expect(fn () => expect(Barable::class)->toOnlyBeUsedIn([User::class]))->toThrowArchitectureViolation(
+        "Expecting 'Tests\Fixtures\Contracts\Models\Barable' not to be used on 'Tests\Fixtures\Models\Product'.",
+        'tests/Fixtures/Models/Product.php',
+        7
+    );
+});

--- a/tests/ToOnlyUse.php
+++ b/tests/ToOnlyUse.php
@@ -1,7 +1,6 @@
 <?php
 
 use Pest\Support\Str;
-use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Fixtures\Contracts\Models\Barable;
 use Tests\Fixtures\Contracts\Models\Fooable;
 use Tests\Fixtures\Contracts\Models\Storable;
@@ -22,20 +21,20 @@ it('passes', function () {
 });
 
 it('fail 1', function () {
-    expect([Product::class])->toOnlyUse([
-        Fooable::class,
-    ]);
-})->throws(
-    ExpectationFailedException::class,
-    "Expecting 'Tests\Fixtures\Models\Product' to only use 'Tests\Fixtures\Contracts\Models\Fooable'. However, it also uses 'Tests\Fixtures\Contracts\Models\Barable'."
-);
+    expect(fn () => expect([Product::class])->toOnlyUse([Fooable::class]))->toThrowArchitectureViolation(
+        "Expecting 'Tests\Fixtures\Models\Product' to only use 'Tests\Fixtures\Contracts\Models\Fooable'. However, it also uses 'Tests\Fixtures\Contracts\Models\Barable'.",
+        'tests/Fixtures/Models/Product.php',
+        7
+    );
+});
 
 it('fail 2', function () {
-    expect(Product::class)->toOnlyUse([]);
-})->throws(
-    ExpectationFailedException::class,
-    "Expecting 'Tests\Fixtures\Models\Product' to use nothing. However, it uses 'Tests\Fixtures\Contracts\Models\Barable'."
-);
+    expect(fn () => expect(Product::class)->toOnlyUse([]))->toThrowArchitectureViolation(
+        "Expecting 'Tests\Fixtures\Models\Product' to use nothing. However, it uses 'Tests\Fixtures\Contracts\Models\Barable'.",
+        'tests/Fixtures/Models/Product.php',
+        7
+    );
+});
 
 test('ignoring', function () {
     expect(Product::class)

--- a/tests/ToUseNothing.php
+++ b/tests/ToUseNothing.php
@@ -1,7 +1,6 @@
 <?php
 
 use Pest\Exceptions\InvalidExpectation;
-use PHPUnit\Framework\ExpectationFailedException;
 use Tests\Fixtures\Contracts\Models\Fooable;
 use Tests\Fixtures\Models\Product;
 
@@ -12,11 +11,13 @@ it('passes', function () {
 });
 
 it('fails 1', function () {
-    expect([Product::class])->toUseNothing();
-})->throws(
-    ExpectationFailedException::class,
-    "Expecting 'Tests\Fixtures\Models\Product' to use nothing. However, it uses 'Tests\Fixtures\Contracts\Models\Barable'."
-);
+    expect(fn () => expect([Product::class])->toUseNothing())
+        ->toThrowArchitectureViolation(
+            "Expecting 'Tests\Fixtures\Models\Product' to use nothing. However, it uses 'Tests\Fixtures\Contracts\Models\Barable'.",
+            'tests/Fixtures/Models/Product.php',
+            7
+        );
+});
 
 test('ignoring', function () {
     expect(Product::class)


### PR DESCRIPTION
This PR finalizes the work started with https://github.com/nunomaduro/collision/pull/266, https://github.com/nunomaduro/collision/commit/932776f1f214616aed073b814ea10e03e7f4953c and https://github.com/pestphp/pest/pull/754

it defines a new `ArchitectureViolationException` that implements collision's `RenderableOnCollisionEditor` allowing to display the exact code snippet where an architecture violation occurred:

https://user-images.githubusercontent.com/8792274/227603858-318d96c0-7220-4c72-ac3a-a3b9491e88d4.png

After this is merged, there are a couple of todos I'd like to implement:

- [ ] fix violation file path by removing `vendor/composer/../../`
- [ ] adding the ability to `RenderableOnCollisionEditor` to not display a custom editor, this will allow to use `ArchitectureViolationException` everywhere, even where a violation snippet is not needed (eg. in toBeUsedIn() expectations)