### PR TITLE
fix: tests not matching any objects are not considered risky

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -60,13 +60,13 @@ final class Blueprint
      */
     public function expectToUse(LayerOptions $options, callable $failure): void
     {
-        AssertLocker::incrementAndLock();
-
         foreach ($this->target->value as $targetValue) {
             $targetLayer = $this->layerFactory->make($options, $targetValue);
 
             foreach ($this->dependencies->values as $dependency) {
                 $dependencyLayer = $this->layerFactory->make($options, $dependency->value);
+
+                AssertLocker::incrementAndLock();
 
                 try {
                     $this->assertDoesNotDependOn($targetLayer, $dependencyLayer);
@@ -90,8 +90,6 @@ final class Blueprint
      */
     public function targeted(callable $callback, LayerOptions $options, callable $failure, callable $lineFinder): void
     {
-        AssertLocker::incrementAndLock();
-
         foreach ($this->target->value as $targetValue) {
             $targetLayer = $this->layerFactory->make($options, $targetValue);
 
@@ -101,6 +99,8 @@ final class Blueprint
                         continue 2;
                     }
                 }
+
+                AssertLocker::incrementAndLock();
 
                 if ($callback($object)) {
                     continue;
@@ -124,8 +124,6 @@ final class Blueprint
      */
     public function expectToOnlyUse(LayerOptions $options, callable $failure): void
     {
-        AssertLocker::incrementAndLock();
-
         foreach ($this->target->value as $targetValue) {
             $allowedUses = array_merge(
                 ...array_map(fn (Layer $layer): array => array_map(
@@ -142,6 +140,8 @@ final class Blueprint
             $layer = $this->layerFactory->make($options, $targetValue);
             foreach ($layer as $object) {
                 foreach ($object->uses as $use) {
+                    AssertLocker::incrementAndLock();
+
                     if (! in_array($use, $allowedUses, true)) {
                         $failure($targetValue, $this->dependencies->__toString(), $use, $this->getUsagePathAndLines($layer, $targetValue, $use));
 


### PR DESCRIPTION
Starting from v2.2.3 Arch tests not matching any object are considered as successful instead of risky.

Given the following test:
```php
test('global')
    ->expect('Invalid\Namespace')
    ->toUseStrictTypes();
```

v2.2.3 returns the following output:

![Screenshot 2023-08-03 at 20 38 47](https://github.com/pestphp/pest-plugin-arch/assets/25097194/40306d57-307d-44c5-a370-5c4342ae5543)

v2.2.2 and before the test has been considered as risky:

![Screenshot 2023-08-03 at 20 38 39](https://github.com/pestphp/pest-plugin-arch/assets/25097194/f9e53e9f-a447-454c-b14f-e7b4dbdd6714)

This behaviour has changed here: https://github.com/pestphp/pest-plugin-arch/commit/f44834b728b44028fb7d99c4e3efc88b699728a8

From the commit message I can't figure out what the reason behind this change was. But I hope my PR does not mess up with it.

@nunomaduro Maybe you help me out here?
