### PR TITLE
[2.x] native functions in toBeUsedInNothing and toBeUsedIn

### DIFF
--- a/src/Blueprint.php
+++ b/src/Blueprint.php
@@ -63,7 +63,7 @@ final class Blueprint
         AssertLocker::incrementAndLock();
 
         foreach ($this->target->value as $targetValue) {
-            $targetLayer = $this->layerFactory->make($options, $targetValue);
+            $targetLayer = $this->layerFactory->make($options, $targetValue, false);
 
             foreach ($this->dependencies->values as $dependency) {
                 $dependencyLayer = $this->layerFactory->make($options, $dependency->value);
@@ -164,7 +164,7 @@ final class Blueprint
         AssertLocker::incrementAndLock();
 
         foreach (Composer::userNamespaces() as $namespace) {
-            $namespaceLayer = $this->layerFactory->make($options, $namespace);
+            $namespaceLayer = $this->layerFactory->make($options, $namespace, false);
 
             foreach ($this->dependencies->values as $dependency) {
                 $namespaceLayer = $namespaceLayer->excludeByNameStart($dependency->value);

--- a/src/Factories/LayerFactory.php
+++ b/src/Factories/LayerFactory.php
@@ -28,7 +28,7 @@ final class LayerFactory
     /**
      * Make a new Layer using the given name.
      */
-    public function make(LayerOptions $options, string $name): Layer
+    public function make(LayerOptions $options, string $name, bool $onlyUserDefinedUses = true): Layer
     {
         $objects = array_map(function (ObjectDescription $object) use ($options): ObjectDescription {
             if ($object instanceof VendorObjectDescription) {
@@ -57,7 +57,7 @@ final class LayerFactory
             );
 
             return $object;
-        }, $this->objectsStorage->allByNamespace($name));
+        }, $this->objectsStorage->allByNamespace($name, $onlyUserDefinedUses));
 
         $layer = Layer::fromBase($objects)->leaveByNameStart($name);
 

--- a/src/Factories/ObjectDescriptionFactory.php
+++ b/src/Factories/ObjectDescriptionFactory.php
@@ -24,7 +24,7 @@ final class ObjectDescriptionFactory
     /**
      * Makes a new Object Description instance, is possible.
      */
-    public static function make(string $filename): ?ObjectDescription
+    public static function make(string $filename, bool $onlyUserDefinedUses = true): ?ObjectDescription
     {
         self::ensureServiceContainerIsInitialized();
 
@@ -49,7 +49,7 @@ final class ObjectDescriptionFactory
             $object->uses = new ObjectUses(array_values(
                 array_filter(
                     iterator_to_array($object->uses->getIterator()),
-                    static fn (string $use): bool => self::isUserDefined($use) && ! self::isSameLayer($object, $use),
+                    static fn (string $use): bool => (! $onlyUserDefinedUses || self::isUserDefined($use)) && ! self::isSameLayer($object, $use),
                 )
             ));
         }

--- a/src/Repositories/ObjectsRepository.php
+++ b/src/Repositories/ObjectsRepository.php
@@ -67,7 +67,7 @@ final class ObjectsRepository
      *
      * @return array<int, ObjectDescription|FunctionDescription>
      */
-    public function allByNamespace(string $namespace): array
+    public function allByNamespace(string $namespace, bool $onlyUserDefinedUses = true): array
     {
         if (function_exists($namespace) && (new ReflectionFunction($namespace))->getName() === $namespace) {
             return [
@@ -91,7 +91,7 @@ final class ObjectsRepository
             }
 
             $objectsPerPrefix = array_values(array_filter(array_reduce($directories, fn (array $files, string $fileOrDirectory): array => array_merge($files, array_values(array_map(
-                static fn (SplFileInfo $file): ?ObjectDescription => ObjectDescriptionFactory::make($file->getPathname()),
+                static fn (SplFileInfo $file): ?ObjectDescription => ObjectDescriptionFactory::make($file->getPathname(), $onlyUserDefinedUses),
                 is_dir($fileOrDirectory) ? iterator_to_array(Finder::create()->files()->in($fileOrDirectory)->name('*.php')) : [new SplFileInfo($fileOrDirectory)],
             ))), [])));
 

--- a/tests/Fixtures/Misc/HasSleepFunction.php
+++ b/tests/Fixtures/Misc/HasSleepFunction.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Fixtures\Misc;
+
+class HasSleepFunction
+{
+    public function startSleeping(): void
+    {
+        sleep(1);
+    }
+}

--- a/tests/ToBeUsedIn.php
+++ b/tests/ToBeUsedIn.php
@@ -13,6 +13,13 @@ it('passes', function () {
     }
 });
 
+it('failure with native functions', function () {
+    expect('sleep')->not->toBeUsedIn('Tests\Fixtures\Misc\HasSleepFunction');
+})->throws(
+    ExpectationFailedException::class,
+    "Expecting 'sleep' not to be used in 'Tests\Fixtures\Misc\HasSleepFunction'."
+);
+
 it('fails 1', function () {
     expect([Fooable::class])
         ->toBeUsedIn(['Tests\Fixtures\Models', 'Tests\Fixtures\Controllers']);

--- a/tests/ToBeUsedInNothing.php
+++ b/tests/ToBeUsedInNothing.php
@@ -30,6 +30,14 @@ it('fails 2', function () {
     );
 });
 
+it('fails with native functions', function () {
+    expect(fn () => expect('sleep')->not->toBeUsed())->toThrowArchitectureViolation(
+        "Expecting 'sleep' not to be used on 'Tests\Fixtures\Misc\HasSleepFunction'.",
+        'tests/Fixtures/Misc/HasSleepFunction.php',
+        10
+    );
+});
+
 test('ignoring', function () {
     expect(Fooable::class)->toBeUsedInNothing()->ignoring('Tests\Fixtures\Models');
 });


### PR DESCRIPTION
This PR will fix https://github.com/pestphp/pest/issues/817 allowing to include native functions when evaluating `toBeUsedInNothing` and `toBeUsedIn` such as:

```php
test('globals')
    ->expect(['sleep', 'usleep'])
    ->not->toBeUsed();
```