### PR TITLE
Fixing PR checks

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -22,6 +22,11 @@ jobs:
         tools: composer:v2
         coverage: none
 
+    - name: Modify composer.json
+      run: >
+        jq '.name |= "pestphp/pest-plugin-arch-dev" | . += {"replace":{"pestphp/pest-plugin-arch": "*"}}' composer.json > composer.json.tmp
+        && mv composer.json.tmp composer.json
+
     - name: Install Dependencies
       run: composer update --prefer-stable --no-interaction --no-progress --ansi
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Modify composer.json
       run: >
-        jq '.name |= "pestphp/pest-plugin-arch-dev" | . += {"replace":{"pestphp/pest-plugin-arch": "*"}}' composer.json > composer.json.tmp
+        jq '. += {"replace":{(.name): "*"}} | .name = (.name + "-dev")' composer.json > composer.json.tmp
         && mv composer.json.tmp composer.json
 
     - name: Install Dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Modify composer.json
       run: >
-        jq '.name |= "pestphp/pest-plugin-arch-dev" | . += {"replace":{"pestphp/pest-plugin-arch": "*"}}' composer.json > composer.json.tmp
+        jq '. += {"replace":{(.name): "*"}} | .name = (.name + "-dev")' composer.json > composer.json.tmp
         && mv composer.json.tmp composer.json
 
     - name: Install PHP dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,11 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
+    - name: Modify composer.json
+      run: >
+        jq '.name |= "pestphp/pest-plugin-arch-dev" | . += {"replace":{"pestphp/pest-plugin-arch": "*"}}' composer.json > composer.json.tmp
+        && mv composer.json.tmp composer.json
+
     - name: Install PHP dependencies
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 


### PR DESCRIPTION
Modified the `composer.json` file to:
1. impersonate as another module to circumvent the cyclic dependency issue;
2. replace any `pestphp/pest-plugin-arch` packages by the current package.