### PR TITLE
Feat: Add modifiers for filtering classes by trait, interface, and inheritance in arch tests

### DIFF
--- a/src/PendingArchExpectation.php
+++ b/src/PendingArchExpectation.php
@@ -73,6 +73,36 @@ final class PendingArchExpectation
     }
 
     /**
+     * Filters the given "targets" by only classes implementing the given interface.
+     */
+    public function implementing(string $interface): self
+    {
+        $this->excludeCallbacks[] = fn (ObjectDescription $object): bool => ! in_array($interface, class_implements($object->name));
+
+        return $this;
+    }
+
+    /**
+     * Filters the given "targets" by only classes extending the given class.
+     */
+    public function extending(string $parentClass): self
+    {
+        $this->excludeCallbacks[] = fn (ObjectDescription $object): bool => ! is_subclass_of($object->name, $parentClass);
+
+        return $this;
+    }
+
+    /**
+     * Filters the given "targets" by only classes using the given trait.
+     */
+    public function usingTrait(string $trait): self
+    {
+        $this->excludeCallbacks[] = fn (ObjectDescription $object): bool => ! in_array($trait, class_uses($object->name));
+
+        return $this;
+    }
+
+    /**
      * Creates an opposite expectation.
      */
     public function not(): self

--- a/tests/Fixtures/Controllers/UserController.php
+++ b/tests/Fixtures/Controllers/UserController.php
@@ -4,9 +4,12 @@ namespace Tests\Fixtures\Controllers;
 
 use Tests\Fixtures\Contracts\Controllers\Indexable;
 use Tests\Fixtures\Controller;
+use Tests\Fixtures\HasResponses;
 
 class UserController extends Controller implements Indexable
 {
+    use HasResponses;
+
     public function index(): array
     {
         return [

--- a/tests/Fixtures/HasResponses.php
+++ b/tests/Fixtures/HasResponses.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Tests\Fixtures;
+
+trait HasResponses {}

--- a/tests/Modifiers.php
+++ b/tests/Modifiers.php
@@ -18,6 +18,6 @@ test('only classes implementing interfaces are tested', function (): void {
 
 test('only class using traits are tested', function (): void {
     expect('Tests\Fixtures\Controllers')
-        ->usingTrait(Tests\Fixtures\HasResponses::class)
+        ->usingTrait(HasResponses::class)
         ->toUseTrait(HasResponses::class);
 });

--- a/tests/Modifiers.php
+++ b/tests/Modifiers.php
@@ -1,0 +1,23 @@
+<?php
+
+use Tests\Fixtures\Contracts\Controllers\Indexable;
+use Tests\Fixtures\Controller;
+use Tests\Fixtures\HasResponses;
+
+test('only classes extending Controller are tested', function (): void {
+    expect('Tests\Fixtures\Controllers')
+        ->extending(Controller::class)
+        ->toExtend(Controller::class);
+});
+
+test('only classes implementing interfaces are tested', function (): void {
+    expect('Tests\Fixtures\Controllers')
+        ->implementing(Indexable::class)
+        ->toImplement(Indexable::class);
+});
+
+test('only class using traits are tested', function (): void {
+    expect('Tests\Fixtures\Controllers')
+        ->usingTrait(Tests\Fixtures\HasResponses::class)
+        ->toUseTrait(HasResponses::class);
+});


### PR DESCRIPTION
This update adds modifiers to filter classes in architectural tests by their traits, interfaces, and inheritance, enabling more precise 
- extending(): Filters classes that extend a specific 
- implementing(): Filters classes that implement a specific interface
- usingTrait(): Filters classes that directly use a specific trait

e.g. 
// Ensure that all Laravel Jobs implementing ShouldQueue use the InteractsWithQueue and Batchable traits
```php
expect('App\Jobs')
    ->classes()
    ->implementing(ShouldQueue::class)
    ->toUseTrait(InteractsWithQueue::class)
```
