### PR TITLE
Fix architecture prefix issue pestphp/pest#966

### DIFF
--- a/src/Repositories/ObjectsRepository.php
+++ b/src/Repositories/ObjectsRepository.php
@@ -147,7 +147,13 @@ final class ObjectsRepository
             if (str_starts_with($name, $prefix)) {
                 $directories = array_values(array_filter($directories, static fn (string $directory): bool => is_dir($directory)));
 
-                $prefix = str_replace('\\', DIRECTORY_SEPARATOR, ltrim(str_replace($prefix, '', $name), '\\'));
+                // Remove the first occurrence of the prefix, if any.
+                // This is needed to avoid having a prefix like "App" and a namespace like "App\Application\..."
+                // This would result in a directory like "\lication\..."
+                $posFirstPrefix = strpos($name, $prefix);
+                $nameWithoutPrefix = $posFirstPrefix !== false ? substr($name, $posFirstPrefix + strlen($prefix)) : $name;
+
+                $prefix = str_replace('\\', DIRECTORY_SEPARATOR, ltrim($nameWithoutPrefix, '\\'));
 
                 $directoriesByNamespace[$name] = [...$directoriesByNamespace[$name] ?? [], ...array_values(array_filter(array_map(static function (string $directory) use ($prefix): string {
                     $fileOrDirectory = $directory.DIRECTORY_SEPARATOR.$prefix;

--- a/tests/Fixtures/Misc/TestsNestedNamespace/IsNested.php
+++ b/tests/Fixtures/Misc/TestsNestedNamespace/IsNested.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\Misc\TestsNestedNamespace;
+
+class IsNested {}

--- a/tests/ObjectsRepository.php
+++ b/tests/ObjectsRepository.php
@@ -1,0 +1,31 @@
+<?php
+
+it('finds objects by namespace', function (string $namespace, array $expected) {
+    $sut = new Pest\Arch\Repositories\ObjectsRepository([
+        'Tests' => [
+            __DIR__,
+        ],
+    ]);
+
+    $result = $sut->allByNamespace($namespace);
+
+    expect($result)->toHaveCount(count($expected));
+
+    foreach ($result as $object) {
+        expect($object->name)->toBeIn($expected);
+    }
+})->with([
+    [
+        'namespace' => 'Tests\Fixtures\Models',
+        'expected' => [
+            'Tests\Fixtures\Models\Product',
+            'Tests\Fixtures\Models\User',
+        ],
+    ],
+    [
+        'namespace' => 'Tests\Fixtures\Misc\TestsNestedNamespace',
+        'expected' => [
+            'Tests\Fixtures\Misc\TestsNestedNamespace\IsNested',
+        ],
+    ],
+]);


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

As described in pestphp/pest#966, this PR includes the #7 fix with a test to prove it.

TL:DR

Any architecture test will **pass** for `App\Foo\Application\Bar`. This is due to the `ObjectRepository` removing every occurrence of 'App' from the namespace - leading it to look for files in `Foo\lication\Bar` - which doesn't exist, so it just simply passes the test.