### PR TITLE
Fix: unused matrix varable in `tests.yml`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
-      run: composer test:unit
+      run: composer test:unit ${{ matrix.parallel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
-      run: composer test:unit ${{ matrix.parallel }}
+      run: composer test:unit -- ${{ matrix.parallel }}

--- a/README.md
+++ b/README.md
@@ -12,4 +12,3 @@ This repository contains the Pest Plugin Arch.
     - Tiktok: **[tiktok.com/@enunomaduro](https://www.tiktok.com/@enunomaduro)**
 
 Pest is an open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.
-

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ This repository contains the Pest Plugin Arch.
     - Tiktok: **[tiktok.com/@enunomaduro](https://www.tiktok.com/@enunomaduro)**
 
 Pest is an open-sourced software licensed under the **[MIT license](https://opensource.org/licenses/MIT)**.
+


### PR DESCRIPTION
The configuration of the workflow has a matrix with 4 different variables:
- os
- php
- dependency-version
- parallel

The `parallel` one looks like it should be used to trigger parallel execution of the tests, but it was never used.
I have changed that, and now the tests are also running in parallel.