### PR TITLE
Feat: Add modifier for filtering abstract classes in arch tests

### DIFF
--- a/src/PendingArchExpectation.php
+++ b/src/PendingArchExpectation.php
@@ -44,6 +44,16 @@ final class PendingArchExpectation
     }
 
     /**
+     * Filters the given "targets" by only abstract classes.
+     */
+    public function abstracts(): self
+    {
+        $this->excludeCallbacks[] = fn(ObjectDescription $object): bool => !$object->reflectionClass->isAbstract();
+
+        return $this;
+    }
+
+    /**
      * Filters the given "targets" by only interfaces.
      */
     public function interfaces(): self

--- a/tests/Fixtures/Misc/Abstracts/Apple.php
+++ b/tests/Fixtures/Misc/Abstracts/Apple.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures\Misc\Abstracts;
+
+class Apple extends Fruit
+{
+
+}

--- a/tests/Fixtures/Misc/Abstracts/Fruit.php
+++ b/tests/Fixtures/Misc/Abstracts/Fruit.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Tests\Fixtures\Misc\Abstracts;
+
+abstract class Fruit
+{
+    public function edible(): bool
+    {
+        return true;
+    }
+}

--- a/tests/Fixtures/Misc/Abstracts/Leef.php
+++ b/tests/Fixtures/Misc/Abstracts/Leef.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures\Misc\Abstracts;
+
+class Leef
+{
+
+}

--- a/tests/Fixtures/Misc/Abstracts/Life.php
+++ b/tests/Fixtures/Misc/Abstracts/Life.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tests\Fixtures\Misc\Abstracts;
+
+interface Life
+{
+
+}

--- a/tests/Modifiers.php
+++ b/tests/Modifiers.php
@@ -21,3 +21,9 @@ test('only class using traits are tested', function (): void {
         ->using(HasResponses::class)
         ->toUseTrait(HasResponses::class);
 });
+
+test('only abstract classes are tested', function (): void {
+    expect('Tests\Fixtures\Misc\Abstracts')
+        ->abstracts()
+        ->toHaveMethod('edible');
+});


### PR DESCRIPTION
This update adds modifier to filter abstract classes in architectural tests.

e.g.
// Ensure that all abstract classes are "auto-resolvable"
```php
expect('App')
    ->abstracts()
    ->toHaveAttribute(AutoResolveClass::class);
```