### PR TITLE
Fixed workflow `tests.yml` to use matrix variable `--parallel`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
         php: ['8.2', '8.3']
         dependency-version: [prefer-lowest, prefer-stable]
-        parallel: ['', '--parallel']
+        parallel: ['', '-- --parallel']
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }} - ${{ matrix.parallel }}
 
@@ -34,4 +34,4 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
-      run: composer test:unit -- ${{ matrix.parallel }}
+      run: composer test:unit ${{ matrix.parallel }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,4 +34,4 @@ jobs:
       run: composer update --${{ matrix.dependency-version }} --no-interaction --no-progress --ansi
 
     - name: Unit Tests
-      run: composer test:unit
+      run: composer test:unit -- ${{ matrix.parallel }}

--- a/src/PendingArchExpectation.php
+++ b/src/PendingArchExpectation.php
@@ -90,7 +90,6 @@ final class PendingArchExpectation
      */
     public function extending(string $parentClass): self
     {
-        // @phpstan-ignore-next-line
         $this->excludeCallbacks[] = fn (ObjectDescription $object): bool => ! is_subclass_of($object->name, $parentClass);
 
         return $this;


### PR DESCRIPTION
Workflow `tests.yml` was not properly using the matrix variable `--parallel`.
I fixed that, and one small problem with PHPStan.