### PR TITLE
fix: clean up scoped autoloaders during arch scans

### DIFF
--- a/src/Factories/ObjectDescriptionFactory.php
+++ b/src/Factories/ObjectDescriptionFactory.php
@@ -6,6 +6,7 @@ namespace Pest\Arch\Factories;
 
 use Pest\Arch\Objects\ObjectDescription;
 use Pest\Arch\Objects\VendorObjectDescription;
+use Pest\Arch\Support\Composer;
 use Pest\Arch\Support\PhpCoreExpressions;
 use PHPUnit\Architecture\Asserts\Dependencies\Elements\ObjectUses;
 use PHPUnit\Architecture\Services\ServiceContainer;
@@ -27,36 +28,38 @@ final class ObjectDescriptionFactory
      */
     public static function make(string $filename, bool $onlyUserDefinedUses = true): ?\PHPUnit\Architecture\Elements\ObjectDescription
     {
-        self::ensureServiceContainerIsInitialized();
+        return Composer::withoutNewLoaders(static function () use ($filename, $onlyUserDefinedUses): ?\PHPUnit\Architecture\Elements\ObjectDescription {
+            self::ensureServiceContainerIsInitialized();
 
-        $isFromVendor = str_contains((string) realpath($filename), DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR);
+            $isFromVendor = str_contains((string) realpath($filename), DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR);
 
-        $originalErrorReportingLevel = error_reporting();
-        error_reporting($originalErrorReportingLevel & ~E_USER_DEPRECATED);
+            $originalErrorReportingLevel = error_reporting();
+            error_reporting($originalErrorReportingLevel & ~E_USER_DEPRECATED);
 
-        try {
-            $object = $isFromVendor
-                ? VendorObjectDescription::make($filename)
-                : ObjectDescription::make($filename);
+            try {
+                $object = $isFromVendor
+                    ? VendorObjectDescription::make($filename)
+                    : ObjectDescription::make($filename);
 
-        } finally {
-            error_reporting($originalErrorReportingLevel);
-        }
+            } finally {
+                error_reporting($originalErrorReportingLevel);
+            }
 
-        if ($object === null) {
-            return null;
-        }
+            if ($object === null) {
+                return null;
+            }
 
-        if (! $isFromVendor) {
-            $object->uses = new ObjectUses(array_values(
-                array_filter(
-                    iterator_to_array($object->uses->getIterator()),
-                    static fn (string $use): bool => (! $onlyUserDefinedUses || self::isUserDefined($use)) && ! self::isSameLayer($object, $use),
-                )
-            ));
-        }
+            if (! $isFromVendor) {
+                $object->uses = new ObjectUses(array_values(
+                    array_filter(
+                        iterator_to_array($object->uses->getIterator()),
+                        static fn (string $use): bool => (! $onlyUserDefinedUses || self::isUserDefined($use)) && ! self::isSameLayer($object, $use),
+                    )
+                ));
+            }
 
-        return $object;
+            return $object;
+        });
     }
 
     /**

--- a/src/Support/Composer.php
+++ b/src/Support/Composer.php
@@ -13,6 +13,27 @@ use Pest\TestSuite;
 final class Composer
 {
     /**
+     * @template TValue
+     *
+     * @param  callable(): TValue  $callback
+     * @return TValue
+     */
+    public static function withoutNewLoaders(callable $callback): mixed
+    {
+        $loaders = ClassLoader::getRegisteredLoaders();
+
+        try {
+            return $callback();
+        } finally {
+            foreach (ClassLoader::getRegisteredLoaders() as $vendorDirectory => $loader) {
+                if (! array_key_exists($vendorDirectory, $loaders)) {
+                    $loader->unregister();
+                }
+            }
+        }
+    }
+
+    /**
      * Gets the list of namespaces defined in the "composer.json" file.
      *
      * @return array<int, string>

--- a/tests/Composer.php
+++ b/tests/Composer.php
@@ -1,5 +1,6 @@
 <?php
 
+use Composer\Autoload\ClassLoader;
 use Pest\Arch\Support\Composer;
 
 it('retrieves user namespaces', function () {
@@ -28,4 +29,20 @@ it('retrieves all non-vendor namespaces with directories', function () {
         ->and(array_values($all))->toContain('Tests')
         ->and($all)->each(fn ($namespace, $directory) => expect($directory)->toBeDirectory())
         ->and(array_keys($user))->each(fn ($directory) => expect($all)->toHaveKey($directory->value));
+});
+
+it('removes composer loaders registered during a callback', function () {
+    $vendorDirectory = __DIR__.'/Fixtures/ScopedVendor';
+    $loader = new ClassLoader($vendorDirectory);
+
+    $result = Composer::withoutNewLoaders(function () use ($loader, $vendorDirectory): string {
+        $loader->register(true);
+
+        expect(ClassLoader::getRegisteredLoaders())->toHaveKey($vendorDirectory);
+
+        return 'done';
+    });
+
+    expect($result)->toBe('done')
+        ->and(ClassLoader::getRegisteredLoaders())->not->toHaveKey($vendorDirectory);
 });


### PR DESCRIPTION
Fix arch object scanning so temporary Composer autoloaders registered while resolving object descriptions are cleaned up after the callback completes.

This prevents Rector-related autoload state discovered during an arch scan from leaking into later tests in the same process.

Fixes pestphp/pest#1732.

Validation:

```bash
docker run --rm -e COMPOSER_ROOT_VERSION=4.x-dev -v "$PWD":/app -w /app composer:2 sh -lc 'git config --global --add safe.directory /app && composer install --no-interaction --prefer-dist'
docker run --rm -e COMPOSER_ROOT_VERSION=4.x-dev -v "$PWD":/app -w /app php:8.4-cli php vendor/bin/pest tests/Composer.php --filter 'removes composer loaders registered during a callback' --compact
docker run --rm -e COMPOSER_ROOT_VERSION=4.x-dev -v "$PWD":/app -w /app php:8.4-cli php vendor/bin/pint --test src/Support/Composer.php src/Factories/ObjectDescriptionFactory.php tests/Composer.php
docker run --rm -e COMPOSER_ROOT_VERSION=4.x-dev -v "$PWD":/app -w /app php:8.4-cli php -d memory_limit=-1 vendor/bin/phpstan analyse --ansi
```
